### PR TITLE
CrProductDirName overrides on Mac

### DIFF
--- a/mac.js
+++ b/mac.js
@@ -108,6 +108,7 @@ module.exports = {
       appPlist.CFBundleDisplayName = opts.name
       appPlist.CFBundleIdentifier = appBundleIdentifier
       appPlist.CFBundleName = opts.name
+      appPlist.CrProductDirName = opts['product-dir-name']
       helperPlist.CFBundleDisplayName = opts.name + ' Helper'
       helperPlist.CFBundleIdentifier = helperBundleIdentifier
       appPlist.CFBundleExecutable = opts.name

--- a/win32.js
+++ b/win32.js
@@ -13,7 +13,7 @@ module.exports = {
       var newExePath = path.join(tempPath, `${opts.name}.exe`)
       var operations = [
         function (cb) {
-          cb()
+          fs.move(path.join(tempPath, 'brave.exe'), newExePath, cb)
         }
       ]
 


### PR DESCRIPTION
Fix filename undefined error in rcedit on Windows

Auditors: @bsclifton, @bridiver, @bbondy