### PR TITLE
Redo CrProductDirName overrides on Mac (backward compatible)

### DIFF
--- a/mac.js
+++ b/mac.js
@@ -108,6 +108,7 @@ module.exports = {
       appPlist.CFBundleDisplayName = opts.name
       appPlist.CFBundleIdentifier = appBundleIdentifier
       appPlist.CFBundleName = opts.name
+      appPlist.CrProductDirName = opts['product-dir-name'] || opts.name
       helperPlist.CFBundleDisplayName = opts.name + ' Helper'
       helperPlist.CFBundleIdentifier = helperBundleIdentifier
       appPlist.CFBundleExecutable = opts.name


### PR DESCRIPTION
Auditors: @bsclifton, @bbondy